### PR TITLE
Split PolysquareLintCommand out of polysquare-ci-scripts.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,24 @@
+language: python
+sudo: false
+python:
+ - '2.7'
+ - '3.4'
+ - pypy
+ - pypy3
+install:
+ - pip install -e .[green] --process-dependency-links --allow-external pychecker --allow-unverified pychecker --allow-external prospector
+ - pip install coverage coveralls
+script:
+ - python setup.py develop
+ - coverage run --source=setuptools_green setup.py green
+after_success:
+ - coveralls
+deploy:
+  provider: pypi
+  user:
+    secure: "SWiGadYn0KyMny4r/jwnmFNASJRCYO9+Mzh8Sjhe4Gy6cFsvRNZpcCBSYmfO+6Cu8ntDkVIWVIh5MZLVKrlI/JlayLgJAPi8oIRua+8NGLlsXXteVdwccc0zYzI9VOH78yy4TTMrTDy8+GbHw0Dpzp+TLze4ET5BMv+sgFdQqhI="
+  password:
+    secure: "MTnHw/FFl/7BEz9TW5NN981qWf76Yg0Lx5nGYYClowKdYEB4CE9zyiXDK0RFI3HYqVUwg81+wSTV4ZaXlagaTC1l7YZjlj2MaV6Fo6wMOT0iZ4coZ+nYJ/zv5LAnPl+iIY4P+IhDoowLGPLug/GtU5fPnoVxz/ZVdw4IdXu/Y20="
+  on:
+    repo: polysquare/setuptools-green
+    branch: master

--- a/setup.py
+++ b/setup.py
@@ -5,14 +5,25 @@
 # See /LICENCE.md for Copyright information
 """Installation and setup script for polysquare-setuptools-lint."""
 
-from polysquare_setuptools_lint import PolysquareLintCommand
+from polysquare_setuptools_lint import can_run_pychecker, PolysquareLintCommand
 
 from setuptools import find_packages
 from setuptools import setup
 
+# Don't install pychecker if we're not on python 2 and CPython
+if can_run_pychecker():
+    additional_linters = ["pychecker"]
+    additional_dependency_links = [
+        ("http://downloads.sourceforge.net/project/pychecker/pychecker/0.8.19/"
+         "pychecker-0.8.19.tar.gz#egg=pychecker-0.8.19")
+    ]
+else:
+    additional_linters = list()
+    additional_dependency_links = list()
+
 setup(name="polysquare-setuptools-lint",
       version="0.0.1",
-      description="""Provides a 'lint' command for setuptools""",
+      description="""Provides a 'polysquarelint' command for setuptools""",
       long_description_markdown_filename="README.md",
       author="Sam Spilsbury",
       author_email="smspillaz@gmail.com",
@@ -32,7 +43,7 @@ setup(name="polysquare-setuptools-lint",
       keywords="development linters",
       packages=find_packages(exclude=["test"]),
       cmdclass={
-          "lint": PolysquareLintCommand
+          "polysquarelint": PolysquareLintCommand
       },
       install_requires=[
           "setuptools",
@@ -46,28 +57,31 @@ setup(name="polysquare-setuptools-lint",
           "pyflakes",
           "pyroma",
           "vulture",
-          "prospector",
+          "prospector>=0.10.1",
           "flake8==2.3.0",
           "flake8-blind-except",
           "flake8-docstrings",
           "flake8-double-quotes",
           "flake8-import-order",
           "flake8-todo",
-          "pychecker",
           "six"
-      ],
+      ] + additional_linters,
       dependency_links=[
-          ("https://github.com/landscapeio/prospector/tarball/master"
-           "#egg=prospector"),
-          ("http://downloads.sourceforge.net/project/pychecker/pychecker/"
-           "0.8.19/pychecker-0.8.19.tar.gz#egg=pychecker-0.8.19")
-      ],
+          ("https://github.com/smspillaz/prospector/tarball/fix-116-builds"
+           "#egg=prospector-0.10.1")
+      ] + additional_dependency_links,
       extras_require={
-          "test": ["testtools"]
+          "green": [
+              "nose",
+              "nose-parameterized",
+              "setuptools-green",
+              "testtools"
+          ]
       },
       entry_points={
           "distutils.commands": [
-              "lint=polysquare_setuptools_lint:PolysquareLintCommand",
+              ("polysquarelint=polysquare_setuptools_lint:"
+               "PolysquareLintCommand"),
           ]
       },
       zip_safe=True,


### PR DESCRIPTION
This will install a command for setuptools named "polysquarelint" which can
be run on any installed program subsequent.

Pass --exclude=PAT1,PAT2 to exclude glob-expression patterns PAT1 and PAT2
from the list of files to be linted.

Pass --suppress=CODE1,CODE2 to suppress reported codes globally.

All linter errors can be suppressed inline by using suppress(CODE1,CODE2)
as either a comment at the end of the line producing the error or the line
directly above it.