### PR TITLE
Filter out duplicate files

### DIFF
--- a/DICTIONARY
+++ b/DICTIONARY
@@ -21,4 +21,5 @@ subclasses
 subdirectories
 suppress
 suppressions
+symlinks
 unittest

--- a/polysquare_setuptools_lint/__init__.py
+++ b/polysquare_setuptools_lint/__init__.py
@@ -460,6 +460,10 @@ class PolysquareLintCommand(setuptools.Command):  # suppress(unused-function)
 
         all_f.append(os.path.join(os.getcwd(), "setup.py"))
 
+        # Remove duplicates which may exist due to symlinks or repeated
+        # packages found by /setup.py
+        all_f = list(set([os.path.realpath(f) for f in all_f]))
+
         exclusions = [
             "*.egg/*",
             "*.eggs/*"

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ if can_run_frosted():
     ADDITIONAL_LINTERS += ["frosted"]
 
 setup(name="polysquare-setuptools-lint",
-      version="0.0.7",
+      version="0.0.8",
       description="""Provides a 'polysquarelint' command for setuptools""",
       long_description_markdown_filename="README.md",
       author="Sam Spilsbury",


### PR DESCRIPTION
Its possible to get duplicate files from scanning the packages
and also always scanning test/ directory.

Scanning the same file twice can cause pychecker to trip up.