### PR TITLE
polysquarelint: Integrate polysquare-style-guide-linter

### DIFF
--- a/DICTIONARY
+++ b/DICTIONARY
@@ -1,4 +1,5 @@
 AppVeyor
+CACHE
 CODE1
 CODE2
 CPython

--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,8 @@ setup(name="polysquare-setuptools-lint",
           "flake8-double-quotes",
           "flake8-import-order",
           "flake8-todo",
-          "six"
+          "six",
+          "polysquare-generic-file-linter>=0.1.11"
       ] + _ADDITIONAL_LINTERS,
       extras_require={
           "upload": ["setuptools-markdown"]

--- a/test/test_polysquare_lint.py
+++ b/test/test_polysquare_lint.py
@@ -339,7 +339,7 @@ class TestPolysquareLintCommand(TestCase):
     @parameterized.expand([
         param("suppress_codes"),
         param("exclusions"),
-        param("stamp_directory")
+        param("cache_directory")
     ])
     def test_passing_non_list_non_string_in_opts_raises(self, attrib):
         """Passing a non-list or non string as an option raises an error."""


### PR DESCRIPTION
In this change, we also introduced the concept of a cache_directory,
which polysquare-style-guide-linter requires to run effectively. The
stamp_directory may be derived from it, but the old behaviour
of allowing it to be specified still exists.